### PR TITLE
feat(planner): Module 5 — Automation Plan Emitter (atoms + selectors + feasibility + CSV/MD)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,13 @@
+# Source uses LF
+*.ts  text eol=lf
+*.tsx text eol=lf
+*.md  text eol=lf
+*.json text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+
+# Generated CSVs must stay CRLF for Excel; keep them as-is and UTF-8
+exports/*.csv -text eol=crlf
 * text=auto eol=lf
 
 *.ts  text eol=lf

--- a/qa-framework/README.md
+++ b/qa-framework/README.md
@@ -21,5 +21,17 @@ pnpm -w prisma:migrate
 
 More detail: see `docs/roadmap.md`.
 
+## Planner v2 — Automation Plan emitter
+
+Cheatsheet:
+
+```powershell
+pnpm planner:v2:adaugare -- --out-csv exports/Plan_Adaugare_v2.csv --out-md docs/Plan_Adaugare_v2.md
+```
+
+Creează automat și:
+- `exports/Adaugare_Automation.csv` (UTF-8 BOM, CRLF)
+- `docs/modules/Adaugare_Automation.md`
+
 
 

--- a/qa-framework/docs/Plan_Adaugare_v2.md
+++ b/qa-framework/docs/Plan_Adaugare_v2.md
@@ -1,18 +1,32 @@
 # Plan Adaugare v2
 
-## Rând 1: Verifică fluxul de adăugare în bucket-ul Formular.
+## Rând 1: Verifică fluxul de adăugare în bucket-ul Tabel.
 
 **Fezabilitate:** B
 
-**Bucket:** Formular · **Oracle:** dom · **Sursă:** us · **Încredere rând:** 0.70 · **Etichete:** crud, create
+**Bucket:** Tabel · **Oracle:** dom · **Sursă:** us · **Încredere rând:** 0.25 · **Etichete:** crud, create
 
 - **Arrange**:
-  - Navighează la /cont/nou
-  - Completează email cu qa@example.com
+  - Deschide aplicația și navighează la ruta 
+  - Completează câmpul valoare cu un exemplu valid (exemplu)
 - **Act**:
-  - Trimite formularul (/cont/nou/submit)
+  - Apasă pe butonul de trimitere ()
 - **Assert**:
-  - Apare mesajul Cont creat cu succes
+  - Verifică existența mesajului de confirmare: 
+
+## Rând 2: Verifică fluxul de adăugare în bucket-ul Formular.
+
+**Fezabilitate:** B
+
+**Bucket:** Formular · **Oracle:** dom · **Sursă:** us · **Încredere rând:** 0.25 · **Etichete:** crud, create
+
+- **Arrange**:
+  - Deschide aplicația și navighează la ruta 
+  - Completează câmpul valoare cu un exemplu valid (exemplu)
+- **Act**:
+  - Apasă pe butonul de trimitere ()
+- **Assert**:
+  - Verifică existența mesajului de confirmare: 
 
 ---
-**Încredere plan (overall):** 0.70
+**Încredere plan (overall):** 0.25

--- a/qa-framework/packages/planner/src/automation/dataProfile.ts
+++ b/qa-framework/packages/planner/src/automation/dataProfile.ts
@@ -1,0 +1,25 @@
+import path from "node:path";
+import fs from "fs-extra";
+
+function loadYamlMaybe(filePath: string): any {
+  if (!fs.existsSync(filePath)) return undefined;
+  const text = fs.readFileSync(filePath, "utf8");
+  try {
+    const YAML = require("yaml");
+    return YAML.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+export function buildDataProfile(projectPath?: string): string {
+  if (projectPath) {
+    const f = path.join(projectPath, "standards", "profiles.yaml");
+    const doc = loadYamlMaybe(f);
+    if (doc && typeof doc.default === "string") return doc.default;
+    if (doc && doc.summary) return String(doc.summary).slice(0, 120);
+  }
+  return "user: seeded; product: generated(minimal); locale: ro-RO";
+}
+
+

--- a/qa-framework/packages/planner/src/automation/feasibility.ts
+++ b/qa-framework/packages/planner/src/automation/feasibility.ts
@@ -1,0 +1,60 @@
+import type { AAAAtoms, Feasibility } from "../types/automation";
+
+export type SelectorNeeds = "none" | "low" | "medium" | "high";
+
+export interface FeasibilityInputs {
+  atoms: AAAAtoms;
+  preferredSelectors: string[]; // e.g., ["data-testid","role"]
+  missingSelectors: string[];   // unresolved selectors
+  hasDynamicContent?: boolean;
+  crossRouteSteps?: number;     // number of distinct routes
+  hasAuthDependencies?: boolean;
+  hasNegativePaths?: boolean;
+  dataProfileComplexity?: "simple" | "mixed" | "complex";
+  oracleKind?: "visual" | "dom" | "api" | "none";
+}
+
+export function deriveSelectorNeeds(preferred: string[], missing: string[]): SelectorNeeds {
+  const total = Math.max(preferred.length, 1);
+  const unresolved = missing.filter((m) => preferred.includes(m)).length;
+  const ratio = unresolved / total;
+  if (unresolved === 0) return "none";
+  if (ratio <= 0.33) return "low";
+  if (ratio <= 0.66) return "medium";
+  return "high";
+}
+
+export function scoreFeasibility(inputs: FeasibilityInputs): { feasibility: Feasibility; selector_needs: SelectorNeeds; rationale: string } {
+  const selector_needs = deriveSelectorNeeds(inputs.preferredSelectors, inputs.missingSelectors);
+
+  const steps = inputs.atoms.setup.length + inputs.atoms.action.length + inputs.atoms.assert.length;
+  const isMultiRoute = (inputs.crossRouteSteps ?? 1) >= 2;
+  const hasDynamic = Boolean(inputs.hasDynamicContent);
+  const auth = Boolean(inputs.hasAuthDependencies);
+  const negatives = Boolean(inputs.hasNegativePaths);
+  const data = inputs.dataProfileComplexity ?? "mixed";
+  const oracle = inputs.oracleKind ?? "dom";
+
+  let tier: Feasibility = "C";
+  const reasons: string[] = [];
+
+  if (selector_needs === "none" && !hasDynamic && !isMultiRoute && data === "simple" && oracle !== "visual") {
+    tier = "A";
+    reasons.push("selectori stabili, date simple, flux unic");
+  } else if ((selector_needs === "low" && !isMultiRoute) || (!hasDynamic && steps <= 8)) {
+    tier = "B";
+    reasons.push("complexitate moderată; selectori acceptabili");
+  } else if (selector_needs === "medium" || isMultiRoute || hasDynamic) {
+    tier = "C";
+    reasons.push("DOM variabil sau mai multe rute");
+  } else if (selector_needs === "high" || oracle === "visual" || data === "complex" || auth) {
+    tier = "D";
+    reasons.push("depinde de async/3rd-party sau oracol neclar");
+  }
+
+  if (negatives) reasons.push("include scenarii negative");
+
+  return { feasibility: tier, selector_needs, rationale: reasons.join("; ") || "OK" };
+}
+
+

--- a/qa-framework/packages/planner/src/automation/selectorStrategy.ts
+++ b/qa-framework/packages/planner/src/automation/selectorStrategy.ts
@@ -1,0 +1,47 @@
+import path from "node:path";
+import fs from "fs-extra";
+
+export interface SelectorStandards {
+  preferred?: string[]; // e.g., ["data-testid","role","aria","label","text","css","xpath"]
+  avoid?: string[];
+}
+
+function loadYamlMaybe(filePath: string): any {
+  if (!fs.existsSync(filePath)) return undefined;
+  const text = fs.readFileSync(filePath, "utf8");
+  try {
+    // lightweight parse to avoid bringing YAML here; rely on planner deps elsewhere
+    const YAML = require("yaml");
+    return YAML.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+export function resolveSelectorStrategy(projectPath?: string, fallbacks: string[] = ["data-testid","role","aria","label","text","css","xpath"]): { strategy: string; ordered: string[] } {
+  let ordered = [...fallbacks];
+  let reason = "implicit defaults";
+  if (projectPath) {
+    const f = path.join(projectPath, "standards", "selectors.yaml");
+    const doc = loadYamlMaybe(f);
+    if (doc && Array.isArray(doc.preferred) && doc.preferred.length) {
+      const uniq = Array.from(new Set<string>(doc.preferred.concat(fallbacks)));
+      ordered = uniq;
+      reason = "project standards";
+    }
+  }
+  const human = (() => {
+    const idxOf = (k: string) => ordered.indexOf(k);
+    const has = (k: string) => idxOf(k) >= 0;
+    const parts: string[] = [];
+    if (has("data-testid")) parts.push("data-testid (preferred)");
+    if (has("role") || has("aria")) parts.push("fallback role/aria");
+    if (has("label") || has("text")) parts.push("avoid text if unstable");
+    if (has("css")) parts.push("css scoped");
+    if (has("xpath")) parts.push("avoid xpath");
+    return `${parts.join("; ")}; reason: ${reason}`;
+  })();
+  return { strategy: human, ordered };
+}
+
+

--- a/qa-framework/packages/planner/src/emit/automation_csv.ts
+++ b/qa-framework/packages/planner/src/emit/automation_csv.ts
@@ -28,7 +28,7 @@ function toCompactJSON(value: unknown): string {
 }
 
 function formatConfidence(n: number): string {
-  return (Math.round(n * 1000) / 1000).toString();
+  return Number.isFinite(n) ? n.toFixed(2) : "";
 }
 
 export function automationPlanToCsvBuffer(rows: PlanRow[]): Buffer {

--- a/qa-framework/packages/planner/src/emit/automation_md.ts
+++ b/qa-framework/packages/planner/src/emit/automation_md.ts
@@ -1,5 +1,16 @@
 import type { PlanRow } from "../v2/types.js";
 
+function badgeFor(feas: string): string {
+  switch (feas) {
+    case "A": return "A 🟢";
+    case "B": return "B 🟡";
+    case "C": return "C 🟠";
+    case "D": return "D 🟣";
+    case "E": return "E 🔴";
+    default: return String(feas || "?");
+  }
+}
+
 export function automationPlanToMarkdown(moduleName: string, rows: PlanRow[]): string {
   const dt = new Date().toISOString();
   const title = `# ${moduleName}: Plan de automatizare\n\n_Generat la ${dt}_\n\n`;
@@ -14,20 +25,28 @@ export function automationPlanToMarkdown(moduleName: string, rows: PlanRow[]): s
   }).join("\n");
   const sections = (rows || []).map((r, i) => {
     const atoms = r.atoms ?? { setup: [], action: [], assert: [] };
+    const feasBadge = badgeFor(r.feasibility ?? "");
+    const aaaBullets = [
+      "### Arrange",
+      ...(atoms.setup || []).map((s: string) => `- ${s}`),
+      "",
+      "### Act",
+      ...(atoms.action || []).map((s: string) => `- ${s}`),
+      "",
+      "### Assert",
+      ...(atoms.assert || []).map((s: string) => `- ${s}`),
+      "",
+    ].join("\n");
     return [
       `\n---\n`,
-      `## ${i + 1}. ${r.bucket ?? "(fără bucket)"} — ${r.tipFunctionalitate ?? ""}\n`,
-      `**Narațiune (RO):** ${r.narrative_ro ?? ""}\n`,
-      `**Selector needs:** ${r.selector_needs ?? ""} | **Strategy:** ${r.selector_strategy ?? ""}\n`,
-      `**Data profile:** ${r.data_profile ?? ""}\n`,
-      `**Feasibility:** ${r.feasibility ?? ""} | **Source:** ${r.source ?? ""} | **Confidence:** ${r.confidence != null ? (Math.round(r.confidence * 1000) / 1000) : ""}\n`,
-      `**Tags:** ${(r.rule_tags ?? []).join(", ")}\n`,
-      `**Notes:** ${r.notes ?? ""}\n`,
-      `\n<details><summary>AAA atoms</summary>\n\n` +
-        "```json\n" +
-        `${JSON.stringify(atoms, null, 2)}\n` +
-        "```\n\n" +
-      `</details>\n`
+      `## ${i + 1}. ${r.bucket ?? "(fără bucket)"} — ${r.narrative_ro ?? ""}\n`,
+      `**Fezabilitate:** ${feasBadge}\n`,
+      `\n**Narațiune:** ${r.narrative_ro ?? ""}\n`,
+      aaaBullets,
+      `**Selecție & Date:** ${r.selector_strategy ?? ""} · ${r.selector_needs ?? ""} · ${r.data_profile ?? ""}\n`,
+      `**Proveniență & Încredere:** ${r.source ?? ""} · ${(r.confidence ?? 0).toFixed(2)}\n`,
+      (r.rule_tags?.length ? `**Etichete reguli:** ${(r.rule_tags || []).map(t => `\`${t}\``).join(", ")}\n` : ""),
+      r.notes ? `**Note:** ${r.notes}\n` : "",
     ].join("");
   }).join("");
   return title + header + "\n" + table + "\n" + sections + "\n";

--- a/qa-framework/packages/planner/src/pipelines/automationPlan.ts
+++ b/qa-framework/packages/planner/src/pipelines/automationPlan.ts
@@ -1,0 +1,58 @@
+import type { PlanV2 } from "../v2/types";
+import type { AutomationPlanRow } from "../types/automation";
+import { resolveSelectorStrategy } from "../automation/selectorStrategy";
+import { buildDataProfile } from "../automation/dataProfile";
+import { scoreFeasibility } from "../automation/feasibility";
+
+export interface AutomationPipelineArgs {
+  plan: PlanV2;
+  moduleName: string;
+  projectPath?: string;
+}
+
+function deriveShortTitle(narrative: string): string {
+  const trimmed = narrative.replace(/\s+/g, " ").trim();
+  return trimmed.length > 80 ? trimmed.slice(0, 77) + "…" : trimmed;
+}
+
+export function buildAutomationPlanRows(args: AutomationPipelineArgs): AutomationPlanRow[] {
+  const { plan, moduleName, projectPath } = args;
+  const out: AutomationPlanRow[] = [];
+  for (const r of plan.rows) {
+    const sel = resolveSelectorStrategy(projectPath);
+    const dataProfile = buildDataProfile(projectPath);
+    const feas = scoreFeasibility({
+      atoms: r.atoms,
+      preferredSelectors: sel.ordered,
+      missingSelectors: r.selector_needs as any,
+      hasDynamicContent: r.oracle_kind === "visual",
+      crossRouteSteps: 1,
+      dataProfileComplexity: (r.data_profile?.required?.length || 0) <= 1 ? "simple" : "mixed",
+      oracleKind: r.oracle_kind as any,
+    });
+    const mapSource = (s: any): "US" | "project" | "defaults" => {
+      if (String(s).toLowerCase() === "us") return "US";
+      if (String(s).toLowerCase() === "project") return "project";
+      return "defaults";
+    };
+    const row: AutomationPlanRow = {
+      module: moduleName,
+      tipFunctionalitate: r.tipFunctionalitate,
+      bucket: r.bucket,
+      narrative_ro: deriveShortTitle(r.narrative_ro),
+      atoms: r.atoms,
+      selector_needs: feas.selector_needs,
+      selector_strategy: sel.strategy,
+      data_profile: dataProfile,
+      feasibility: feas.feasibility,
+      source: mapSource(r.source),
+      confidence: Math.min(1, Math.max(0, Number((r.confidence ?? 0).toFixed(2)) || 0)),
+      rule_tags: r.rule_tags || [],
+      notes: feas.rationale,
+    };
+    out.push(row);
+  }
+  return out;
+}
+
+

--- a/qa-framework/packages/planner/src/pipelines/automationPlan.ts
+++ b/qa-framework/packages/planner/src/pipelines/automationPlan.ts
@@ -48,7 +48,7 @@ export function buildAutomationPlanRows(args: AutomationPipelineArgs): Automatio
       source: mapSource(r.source),
       confidence: Math.min(1, Math.max(0, Number((r.confidence ?? 0).toFixed(2)) || 0)),
       rule_tags: r.rule_tags || [],
-      notes: feas.rationale,
+      notes: [feas.rationale].filter(Boolean).join(""),
     };
     out.push(row);
   }

--- a/qa-framework/packages/planner/src/types/automation.ts
+++ b/qa-framework/packages/planner/src/types/automation.ts
@@ -1,0 +1,25 @@
+export type AAAAtoms = { setup: string[]; action: string[]; assert: string[] };
+
+export type Feasibility = "A" | "B" | "C" | "D" | "E";
+export type SelectorNeeds = "none" | "low" | "medium" | "high";
+export type SourceProvenance = "US" | "project" | "defaults";
+
+export interface AutomationPlanRow {
+  module: string;                    // e.g., "Adăugare"
+  tipFunctionalitate: string;        // Excel category
+  bucket: string;                    // from US_Normalized buckets or project fallback
+  narrative_ro: string;              // Romanian narrative, compact
+  atoms: AAAAtoms;                   // Arrange/Act/Assert steps (strings, imperative, RO)
+  selector_needs: SelectorNeeds;     // heuristic result
+  selector_strategy: string;         // selected approach + short rationale
+  data_profile: string;              // named profile or JSON summary
+  feasibility: Feasibility;          // A–E
+  source: SourceProvenance;          // provenance of fields (US/project/defaults)
+  confidence: number;                // 0..1 with two decimals
+  rule_tags: string[];               // tags from rule pack
+  notes: string;                     // reviewer hints
+}
+
+export type AutomationPlan = AutomationPlanRow[];
+
+

--- a/qa-framework/packages/planner/src/v2/generate.ts
+++ b/qa-framework/packages/planner/src/v2/generate.ts
@@ -97,7 +97,7 @@ export async function generatePlanV2(args: GenerateArgs): Promise<PlanV2> {
     // Provenance examples for fields/messages (US > Project > Defaults)
     const pFields = pickWithProvenance(us?.fields, project?.fields, []);
     const pMessages = pickWithProvenance(us?.messages, project?.messages, {});
-    const usedProject = pFields.source === "project" || pMessages.source === "project";
+    const usedFallback = pFields.source !== "us" || pMessages.source !== "us";
 
     const baseConfidence: number =
       typeof us?.confidence?.overall === "number" ? us.confidence.overall : rules.min_confidence ?? 0.6;
@@ -118,7 +118,7 @@ export async function generatePlanV2(args: GenerateArgs): Promise<PlanV2> {
         fields: { all: pFields.source },
         messages: { all: pMessages.source },
       },
-      confidence: bumpConfidence(baseConfidence, applyProjectFallbacks && usedProject),
+      confidence: bumpConfidence(baseConfidence, applyProjectFallbacks && usedFallback),
       rule_tags: rules.rule_tags ?? [],
       notes: undefined,
     };

--- a/qa-framework/packages/planner/src/v2/generate.ts
+++ b/qa-framework/packages/planner/src/v2/generate.ts
@@ -58,11 +58,14 @@ export async function generatePlanV2(args: GenerateArgs): Promise<PlanV2> {
 
   // buckets policy
   const effectiveBuckets = (() => {
-    const usBuckets: string[] = Array.isArray(us?.buckets) ? us.buckets : [];
-    if ((buckets ?? rules.buckets_policy) === "strict") return usBuckets.length ? usBuckets : ["General"];
+    const usBucketsRaw: any[] = Array.isArray(us?.buckets) ? us.buckets : [];
+    const usBucketNames: string[] = usBucketsRaw
+      .map((b) => (typeof b === "string" ? b : (b && typeof b.name === "string" ? b.name : undefined)))
+      .filter((v: any): v is string => Boolean(v));
+    if ((buckets ?? rules.buckets_policy) === "strict") return usBucketNames.length ? usBucketNames : ["General"];
     // lax: try to extend with project coverage if present
     const projBuckets: string[] = Array.isArray(project?.coverage?.buckets) ? project.coverage.buckets : [];
-    const merged = new Set<string>([...usBuckets, ...projBuckets]);
+    const merged = new Set<string>([...usBucketNames, ...projBuckets]);
     return merged.size ? Array.from(merged) : ["General"];
   })();
 

--- a/qa-framework/packages/planner/src/v2/provenance.ts
+++ b/qa-framework/packages/planner/src/v2/provenance.ts
@@ -10,9 +10,9 @@ export function pickWithProvenance<T>(
   return { value: defaultVal, source: "defaults" };
 }
 
-export function bumpConfidence(base: number, usedProject: boolean): number {
-  // Bump +0.1 if project filled a gap; cap at 1.0
-  const inc = usedProject ? 0.1 : 0;
+export function bumpConfidence(base: number, usedFallback: boolean): number {
+  // Bump +0.05 when project/defaults filled a gap; cap at 1.0
+  const inc = usedFallback ? 0.05 : 0;
   return Math.min(1, base + inc);
 }
 

--- a/qa-framework/packages/planner/test/automationCsv.spec.ts
+++ b/qa-framework/packages/planner/test/automationCsv.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { automationPlanToCsvBuffer, AUTOMATION_CSV_COLUMNS } from "../src/emit/automation_csv";
+
+const sample = [
+  {
+    module: "Adăugare",
+    tipFunctionalitate: "Adăugare",
+    bucket: "General",
+    narrative_ro: "Utilizatorul adaugă un element.",
+    atoms: { setup: ["autentificare"], action: ["clic pe Adaugă"], assert: ["vede confirmare"] },
+    selector_needs: "low",
+    selector_strategy: "data-testid (preferred); fallback role/aria; avoid text; reason: stable ids",
+    data_profile: "user: seeded",
+    feasibility: "B",
+    source: "US",
+    confidence: 0.87,
+    rule_tags: ["happy-path","auth"],
+    notes: "ok",
+  },
+  {
+    module: "Adăugare",
+    tipFunctionalitate: "Adăugare",
+    bucket: "Edge",
+    narrative_ro: """Caz cu diacritice și "ghilimele""",
+    atoms: { setup: [], action: ["introduce date"], assert: ["eroare vizibilă"] },
+    selector_needs: "medium",
+    selector_strategy: "role/aria; no testids; mitigate with scoped queries",
+    data_profile: "product: generated(minimal)",
+    feasibility: "C",
+    source: "defaults",
+    confidence: 0.55,
+    rule_tags: [],
+    notes: "verificare manuală",
+  },
+] as any[];
+
+function parseCsvLine(line: string): string[] {
+  const out: string[] = [];
+  let cur = "";
+  let inQ = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i]!;
+    if (inQ) {
+      if (ch === '"') {
+        if (line[i + 1] === '"') { cur += '"'; i++; } else { inQ = false; }
+      } else { cur += ch; }
+    } else {
+      if (ch === ',') { out.push(cur); cur = ""; }
+      else if (ch === '"') { inQ = true; }
+      else { cur += ch; }
+    }
+  }
+  out.push(cur);
+  return out;
+}
+
+describe("automation CSV emitter", () => {
+  it("writes BOM, CRLF, ordered headers and quoted fields", () => {
+    const buf = automationPlanToCsvBuffer(sample as any);
+    const text = buf.toString("utf8");
+    expect(text.startsWith("\uFEFF")).toBe(true);
+    const [bomless, ...rest] = [text.slice(1)];
+    const lines = bomless.split("\r\n");
+    expect(lines[0]).toBe(AUTOMATION_CSV_COLUMNS.join(","));
+    const fields = parseCsvLine(lines[1] || "");
+    expect(fields.length).toBe(AUTOMATION_CSV_COLUMNS.length);
+    // narrative with quotes is properly escaped
+    const fields2 = parseCsvLine(lines[2] || "");
+    expect(fields2[3] || "").toMatch(/""ghilimele""/);
+  });
+});
+
+

--- a/qa-framework/packages/planner/test/automationMd.spec.ts
+++ b/qa-framework/packages/planner/test/automationMd.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { automationPlanToMarkdown } from "../src/emit/automation_md";
+
+const rows: any[] = [
+  {
+    module: "Adăugare",
+    tipFunctionalitate: "Adăugare",
+    bucket: "General",
+    narrative_ro: "Utilizatorul adaugă un element.",
+    atoms: { setup: ["autentificare"], action: ["clic pe Adaugă"], assert: ["vede confirmare"] },
+    selector_needs: "low",
+    selector_strategy: "data-testid (preferred); fallback role/aria; avoid text; reason: stable ids",
+    data_profile: "user: seeded",
+    feasibility: "A",
+    source: "US",
+    confidence: 0.87,
+    rule_tags: ["happy-path","auth"],
+    notes: "ok",
+  },
+];
+
+describe("automation MD emitter", () => {
+  it("renders title, sections, and feasibility badge", () => {
+    const md = automationPlanToMarkdown("Adăugare", rows as any);
+    expect(md).toContain("# Adăugare: Plan de automatizare");
+    expect(md).toContain("## 1. General — Utilizatorul adaugă un element.");
+    expect(md).toContain("Fezabilitate: A 🟢");
+    expect(md).toContain("### Arrange");
+    expect(md).toContain("### Act");
+    expect(md).toContain("### Assert");
+  });
+});
+
+

--- a/qa-framework/packages/planner/test/feasibility.spec.ts
+++ b/qa-framework/packages/planner/test/feasibility.spec.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { scoreFeasibility } from "../src/automation/feasibility";
+
+describe("automation feasibility scorer", () => {
+  it("rates A for stable simple single-route", () => {
+    const res = scoreFeasibility({
+      atoms: { setup: ["autentificare"], action: ["navigheaza"], assert: ["vede pagina"] },
+      preferredSelectors: ["data-testid","role"],
+      missingSelectors: [],
+      hasDynamicContent: false,
+      crossRouteSteps: 1,
+      dataProfileComplexity: "simple",
+      oracleKind: "dom",
+    });
+    expect(res.feasibility).toBe("A");
+    expect(["none","low","medium","high"]).toContain(res.selector_needs);
+  });
+
+  it("rates C or worse for medium/high selector needs or dynamic content", () => {
+    const res = scoreFeasibility({
+      atoms: { setup: [], action: new Array(6).fill("pas"), assert: ["ok"] },
+      preferredSelectors: ["data-testid","role"],
+      missingSelectors: ["data-testid"],
+      hasDynamicContent: true,
+      crossRouteSteps: 2,
+      dataProfileComplexity: "mixed",
+      oracleKind: "visual",
+    });
+    expect(["C","D","E"]).toContain(res.feasibility);
+  });
+});
+
+


### PR DESCRIPTION
New emitters produce:

docs/modules/<Module>_Automation.md (RO narrative, AAA atoms, feasibility badges, provenance)

exports/<Module>_Automation.csv (BOM+CRLF; exact headers; quoted/escaped)

Added heuristics: selector_strategy, data_profile, feasibility (A–E), selector_needs, rule_tags, notes (with rationale)

Confidence shown with 2 decimals; +0.05 bump when using project/defaults (capped at 1.00)

Review tools: strip UTF-8 BOM; Windows e2e uses execaNode launcher

Why: Delivers the Automation plan as the single source for later codegen & review, consistent with the QA process and project roadmap.